### PR TITLE
edit: competition page to have competition detail carousel

### DIFF
--- a/components/CompetitionDetails.js
+++ b/components/CompetitionDetails.js
@@ -1,190 +1,258 @@
 // components/CompetitionDetails.js
+import { useEffect, useMemo, useRef, useState } from "react";
+
 export default function CompetitionDetails({ competition }) {
+  const [active, setActive] = useState(0);
+  const headerRef = useRef(null);
+  const containerRef = useRef(null);
+  const startXRef = useRef(null);
+  const [slideH, setSlideH] = useState(0);
+
+  // Compute slide height so each slide fills exactly the viewport below the header
+  const recalc = () => {
+    const headerH = headerRef.current?.offsetHeight ?? 0;
+    const vh = window.innerHeight;
+    // Add a small buffer to account for borders / shadows so the slide doesn't overflow
+    setSlideH(Math.max(240, vh - headerH - 24));
+  };
+
+  useEffect(() => {
+    recalc();
+    window.addEventListener("resize", recalc);
+    return () => window.removeEventListener("resize", recalc);
+  }, []);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "ArrowRight") next();
+      else if (e.key === "ArrowLeft") prev();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, competition.sections.length]);
+
+  const next = () => setActive((i) => (i + 1) % competition.sections.length);
+  const prev = () =>
+    setActive((i) => (i - 1 + competition.sections.length) % competition.sections.length);
+
+  const setIndex = (i) => setActive(i);
+
+  // Touch/Pointer swipe
+  const onPointerDown = (e) => {
+    startXRef.current = e.clientX ?? e.touches?.[0]?.clientX ?? 0;
+  };
+  const onPointerUp = (e) => {
+    const endX = e.clientX ?? e.changedTouches?.[0]?.clientX ?? 0;
+    if (startXRef.current == null) return;
+    const dx = endX - startXRef.current;
+    if (Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+    startXRef.current = null;
+  };
+
+  const slideStyle = useMemo(
+    () => ({ height: `${slideH}px` }),
+    [slideH]
+  );
+
   return (
     <div className="lg:col-span-1">
-      {/* Custom Fonts Import */}
-      <style jsx global>{`
-        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@300;400;500;600;700&display=swap');
-        
-        .font-playfair { font-family: 'Playfair Display', serif; }
-        .font-inter { font-family: 'Inter', sans-serif; }
-        
-        .competition-title {
-          background: linear-gradient(135deg, #FF8C00, #D2691E, #CC5500);
-          -webkit-background-clip: text;
-          -webkit-text-fill-color: transparent;
-          background-clip: text;
-        }
-        
-        .section-number {
-          background: linear-gradient(135deg, #FF8C00, #D2691E);
-          background-clip: text;
-          -webkit-background-clip: text;
-          -webkit-text-fill-color: transparent;
-        }
-        
-        .compact-prose p {
-          text-align: left;
-          line-height: 1.5;
-        }
-      `}</style>
-
-      <div className="space-y-6">
-        {/* Compact Competition Header */}
-        <div className="relative overflow-hidden bg-gradient-to-br from-orange-600 via-amber-600 to-orange-700 rounded-xl p-6 text-white shadow-lg">
-          {/* Subtle decorative elements */}
-          <div className="absolute top-0 right-0 w-20 h-20 bg-white/10 rounded-full -translate-y-10 translate-x-10"></div>
-          <div className="absolute bottom-0 left-0 w-16 h-16 bg-white/5 rounded-full translate-y-8 -translate-x-8"></div>
-          
-          <div className="relative z-10">
-            <div className="flex items-start mb-4">
-              <div className="text-3xl mr-4 filter drop-shadow-md">{competition.icon}</div>
-              <div className="flex-1 min-w-0">
-                <div className="mb-2">
-                  <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold bg-white/20 text-white/90 backdrop-blur-sm">
-                    Competition #{competition.id}
-                  </span>
-                </div>
-                <h1 className="font-playfair text-2xl md:text-3xl font-bold mb-2 leading-tight">
-                  {competition.title}
-                </h1>
-                <p className="font-inter text-white/90 text-sm leading-relaxed mb-4">
-                  {competition.description}
-                </p>
-              </div>
+      {/* /* Custom Fonts Import */}
+      <div className="space-y-4">
+        {/* Compact Header */}
+        <div
+          ref={headerRef}
+          className="relative bg-gradient-to-r from-orange-600 to-amber-600 rounded-lg p-3 sm:p-4 sm:ml-8 sm:mr-4 text-white shadow-md"
+        >
+          <div className="flex items-center gap-2 sm:gap-3">
+            <div className="text-lg sm:text-2xl flex-shrink-0">{competition.icon}</div>
+            <div className="flex-1 min-w-0">
+              <h1 className="text-sm sm:text-xl md:text-3xl font-bold text-white truncate">
+                {competition.title}
+              </h1>
+              <span className="inline-flex items-center px-1.5 py-0.5 sm:px-2 rounded text-xs font-medium bg-white/20 text-white/90 mt-0.5 sm:mt-1">
+                Competition #{competition.id}
+              </span>
             </div>
-            
-            <div className="flex items-center justify-between pt-4 border-t border-white/20">
-              <div className="flex items-center text-white/90">
-                <div className="w-8 h-8 bg-white/20 rounded-lg flex items-center justify-center mr-2 backdrop-blur-sm">
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                </div>
-                <div>
-                  <span className="font-inter text-xs text-white/70 block">Deadline</span>
-                  <span className="font-inter font-semibold text-sm">{competition.deadline}</span>
-                </div>
-              </div>
-              
-              <div className="inline-flex items-center px-3 py-1 bg-white/20 backdrop-blur-sm rounded-lg">
-                <div className="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></div>
-                <span className="font-inter font-medium text-white text-sm">Active</span>
-              </div>
+            <div className="text-right flex-shrink-0">
+              <span className="font-inter text-xs text-white/70 block hidden sm:block">Deadline</span>
+              <span className="font-inter font-semibold text-xs sm:text-sm">{competition.deadline}</span>
             </div>
           </div>
         </div>
 
-        {/* Compact Competition Sections */}
-        {competition.sections.map((section, index) => (
-          <section
-            key={section.id}
-            id={section.id}
-            className="group relative bg-white/95 backdrop-blur-sm rounded-xl border border-orange-100/50 shadow-md hover:shadow-lg transition-all duration-300"
+        {/* FULL-VIEW CAROUSEL (slides fill the viewport below the header) */}
+        <div
+          ref={containerRef}
+          className="relative select-none"
+          onMouseDown={onPointerDown}
+          onMouseUp={onPointerUp}
+          onTouchStart={onPointerDown}
+          onTouchEnd={onPointerUp}
+        >
+          {/* Slides track */}
+          <div
+            className="relative w-full overflow-hidden rounded-xl"
+            style={slideStyle}
           >
-            {/* Subtle hover effect */}
-            <div className="absolute inset-0 bg-gradient-to-br from-orange-50/30 via-transparent to-amber-50/30 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            
-            <div className="relative z-10 p-6">
-              {/* Compact Section Header */}
-              <div className="flex items-start mb-4">
-                <div className="flex-shrink-0 mr-4">
-                  <div className="w-10 h-10 bg-gradient-to-br from-orange-100 to-amber-100 border border-orange-200 rounded-lg flex items-center justify-center shadow-sm">
-                    <span className="section-number font-playfair font-bold text-sm">
-                      {String(index + 1).padStart(2, '0')}
-                    </span>
-                  </div>
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h2 className="font-playfair text-xl md:text-2xl font-bold text-gray-900 mb-2 leading-tight">
-                    {section.title}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <div className="h-0.5 w-12 bg-gradient-to-r from-orange-500 to-amber-500 rounded-full"></div>
-                    <div className="h-0.5 w-6 bg-gradient-to-r from-amber-300 to-orange-300 rounded-full opacity-60"></div>
-                    <div className="h-0.5 w-3 bg-orange-200 rounded-full"></div>
-                  </div>
-                </div>
-              </div>
-              
-              {/* Compact Content */}
-              <div className="compact-prose">
-                {section.content.split('\n').map((paragraph, idx) => {
-                  // Handle bullet points
-                  if (paragraph.trim().startsWith('•')) {
-                    return (
-                      <div key={idx} className="flex items-start my-2">
-                        <div className="flex-shrink-0 mt-1.5 mr-3">
-                          <div className="w-1.5 h-1.5 bg-gradient-to-br from-orange-400 to-amber-500 rounded-full"></div>
-                        </div>
-                        <p className="font-inter text-gray-700 leading-relaxed text-sm">
-                          {paragraph.trim().substring(1).trim()}
-                        </p>
-                      </div>
-                    );
-                  }
-                  
-                  // Handle bold headers
-                  if (paragraph.includes('**')) {
-                    const parts = paragraph.split('**');
-                    return (
-                      <p key={idx} className="font-inter text-gray-700 leading-relaxed mb-3 text-sm">
-                        {parts.map((part, partIdx) => 
-                          partIdx % 2 === 1 ? (
-                            <span key={partIdx} className="font-playfair font-semibold text-base text-orange-800">
-                              {part}
+            <div
+              className="flex h-full transition-transform duration-500 ease-out"
+              style={{ transform: `translateX(-${active * 100}%)` }}
+            >
+              {competition.sections.map((section, index) => (
+                <div
+                  key={section.id}
+                  className="min-w-full h-[75vh] sm:p-4 sm:pl-8"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label={`${index + 1} of ${competition.sections.length}`}
+                >
+                  <article
+                    className="group relative bg-white/95 backdrop-blur-sm rounded-xl border border-orange-100/50 shadow-md hover:shadow-lg transition-all duration-300 h-full flex flex-col"
+                  >
+                    {/* Subtle hover gradient */}
+                    <div className="absolute inset-0 bg-gradient-to-br from-orange-50/30 via-transparent to-amber-50/30 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
+                    <div className="relative z-10 p-6 flex-1 overflow-y-auto">
+                      {/* Section header */}
+                      <div className="flex items-start mb-4">
+                        <div className="flex-shrink-0 mr-4">
+                          <div className="w-10 h-10 bg-gradient-to-br from-orange-100 to-amber-100 border border-orange-200 rounded-lg flex items-center justify-center shadow-sm">
+                            <span className="section-number font-playfair font-bold text-sm text-black">
+                              {String(index + 1).padStart(2, "0")}
                             </span>
-                          ) : (
-                            <span key={partIdx}>{part}</span>
-                          )
-                        )}
-                      </p>
-                    );
-                  }
-                  
-                  // Handle regular paragraphs
-                  if (paragraph.trim()) {
-                    return (
-                      <p key={idx} className="font-inter text-gray-700 leading-relaxed mb-3 text-sm">
-                        {paragraph}
-                      </p>
-                    );
-                  }
-                  
-                  return null;
-                })}
-              </div>
-              
-              {/* Compact Section Progress */}
-              <div className="mt-6 pt-3 border-t border-orange-100">
-                <div className="flex items-center justify-between">
-                  <span className="font-inter text-xs font-medium text-orange-600">
-                    Section {index + 1} of {competition.sections.length}
-                  </span>
-                  <div className="flex items-center space-x-1">
-                    {competition.sections.map((_, idx) => (
-                      <div
-                        key={idx}
-                        className={`
-                          w-2 h-2 rounded-full transition-all duration-300 
-                          ${idx <= index 
-                            ? 'bg-gradient-to-br from-orange-500 to-amber-500' 
-                            : 'bg-orange-200'
+                          </div>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h2 className="font-playfair text-xl md:text-2xl font-bold text-gray-900 mb-2 leading-tight">
+                            {section.title}
+                          </h2>
+                          <div className="flex items-center gap-2">
+                            <div className="h-0.5 w-12 bg-gradient-to-r from-orange-500 to-amber-500 rounded-full" />
+                            <div className="h-0.5 w-6 bg-gradient-to-r from-amber-300 to-orange-300 rounded-full opacity-60" />
+                            <div className="h-0.5 w-3 bg-orange-200 rounded-full" />
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Section content */}
+                      <div className="compact-prose">
+                        {section.content.split("\n").map((paragraph, idx) => {
+                          // bullets
+                          if (paragraph.trim().startsWith("•")) {
+                            return (
+                              <div key={idx} className="flex items-start my-2">
+                                <div className="flex-shrink-0 mt-1.5 mr-3">
+                                  <div className="w-1.5 h-1.5 bg-gradient-to-br from-orange-400 to-amber-500 rounded-full" />
+                                </div>
+                                <p className="font-inter text-gray-700 leading-relaxed text-sm">
+                                  {paragraph.trim().substring(1).trim()}
+                                </p>
+                              </div>
+                            );
                           }
-                        `}
-                      />
-                    ))}
-                  </div>
+
+                          // bold spans using **...**
+                          if (paragraph.includes("**")) {
+                            const parts = paragraph.split("**");
+                            return (
+                              <p key={idx} className="font-inter text-gray-700 leading-relaxed mb-3 text-sm">
+                                {parts.map((part, partIdx) =>
+                                  partIdx % 2 === 1 ? (
+                                    <span key={partIdx} className="font-playfair font-semibold text-base text-orange-800">
+                                      {part}
+                                    </span>
+                                  ) : (
+                                    <span key={partIdx}>{part}</span>
+                                  )
+                                )}
+                              </p>
+                            );
+                          }
+
+                          if (paragraph.trim()) {
+                            return (
+                              <p key={idx} className="font-inter text-gray-700 leading-relaxed mb-3 text-sm">
+                                {paragraph}
+                              </p>
+                            );
+                          }
+                          return null;
+                        })}
+                      </div>
+                    </div>
+
+                    {/* Slide footer: progress */}
+                    <div className="px-6 py-3 border-t border-orange-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-inter text-xs font-medium text-orange-600">
+                          Section {index + 1} of {competition.sections.length}
+                        </span>
+                        <div className="flex items-center space-x-1">
+                          {competition.sections.map((_, idx) => (
+                            <div
+                              key={idx}
+                              className={`w-2 h-2 rounded-full transition-all duration-300 ${
+                                idx <= index
+                                  ? "bg-gradient-to-br from-orange-500 to-amber-500"
+                                  : "bg-orange-200"
+                              }`}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </article>
                 </div>
-              </div>
+              ))}
             </div>
-          </section>
-        ))}
-        
-        {/* Compact Completion Indicator */}
-        <div className="relative bg-gradient-to-br from-emerald-50 to-green-50 rounded-xl p-6 text-center border border-emerald-200/50 shadow-md">
-          <div className="absolute top-0 right-0 w-12 h-12 bg-gradient-to-bl from-emerald-200/20 to-transparent rounded-full"></div>
-          
+          </div>
+
+          {/* Nav buttons */}
+          <div className="pointer-events-none">
+            <button
+              type="button"
+              aria-label="Previous"
+              onClick={prev}
+              className="pointer-events-auto absolute -left-4 sm:left-1 cursor-pointer top-2/5 -translate-y-1/2 w-10 h-10 rounded-xl bg-white/80 text-black hover:bg-white shadow-md border border-black flex items-center justify-center backdrop-blur-sm transition"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              aria-label="Next"
+              onClick={next}
+              className="pointer-events-auto absolute -right-4 top-2/5 cursor-pointer -translate-y-1/2 w-10 h-10 rounded-xl bg-white/80 text-black hover:bg-white shadow-md border border-black flex items-center justify-center backdrop-blur-sm transition"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Dots */}
+          {/* <div className="mt-3 flex items-center justify-center gap-2">
+            {competition.sections.map((_, i) => (
+              <button
+                key={i}
+                aria-label={`Go to slide ${i + 1}`}
+                className={`w-2.5 h-2.5 rounded-full transition ${
+                  i === active ? "bg-orange-500" : "bg-orange-200 hover:bg-orange-300"
+                }`}
+                onClick={() => setIndex(i)}
+              />
+            ))}
+          </div> */}
+        </div>
+
+        {/* Completion indicator (kept) */}
+        {/* <div className="relative bg-gradient-to-br from-emerald-50 to-green-50 rounded-xl p-6 text-center border border-emerald-200/50 shadow-md hidden">
+          <div className="absolute top-0 right-0 w-12 h-12 bg-gradient-to-bl from-emerald-200/20 to-transparent rounded-full" />
           <div className="relative z-10">
             <div className="w-12 h-12 bg-gradient-to-br from-emerald-500 to-green-600 text-white rounded-xl flex items-center justify-center mx-auto mb-4 shadow-md">
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -204,7 +272,7 @@ export default function CompetitionDetails({ competition }) {
               <span className="font-inter font-medium text-xs">Ready to submit</span>
             </div>
           </div>
-        </div>
+        </div> */}
       </div>
     </div>
   );

--- a/components/SubmissionPanel.js
+++ b/components/SubmissionPanel.js
@@ -128,7 +128,7 @@ export default function SubmissionPanel({ competitionId }) {
         }
       `}</style>
 
-      <div className="lg:col-span-1">
+      <div className="lg:col-span-1 text-black">
         <div className="sticky top-8 bg-white/95 backdrop-blur-md rounded-2xl border border-orange-100/50 shadow-xl p-6 overflow-hidden relative">
           {/* Background decoration */}
           <div className="absolute top-0 right-0 w-20 h-20 bg-gradient-to-bl from-orange-200/20 to-transparent rounded-full"></div>
@@ -317,7 +317,7 @@ export default function SubmissionPanel({ competitionId }) {
             </form>
 
             {/* Enhanced Help Section */}
-            <div className="mt-6 pt-4 border-t border-orange-100/50">
+            {/* <div className="mt-6 pt-4 border-t border-orange-100/50">
               <h4 className="text-sm font-semibold text-orange-800 mb-3 font-playfair">Need Help?</h4>
               <div className="space-y-2 text-xs text-orange-700/80 font-inter">
                 <div className="flex items-center gap-2">
@@ -333,7 +333,7 @@ export default function SubmissionPanel({ competitionId }) {
                   <span>Email: support@jyot.in</span>
                 </div>
               </div>
-            </div>
+            </div> */}
           </div>
         </div>
       </div>

--- a/data/competitions.js
+++ b/data/competitions.js
@@ -109,18 +109,7 @@ const generateSectionsForCompetition = (competition) => {
     • Midjourney - High-quality artistic images
     • DALL-E 3 - Creative image generation
     • Stable Diffusion - Open-source image creation
-    • Adobe Firefly - Integrated creative tools
-    
-    **Audio & Music:**
-    • Suno AI - Music and song generation
-    • ElevenLabs - Voice synthesis and audio
-    • Mubert - AI-generated background music
-    
-    **Free Resources:**
-    • Hugging Face - Open-source AI models
-    • Google Colab - Free computing resources
-    • YouTube tutorials for each tool
-    • Community Discord for support`
+    • Adobe Firefly - Integrated creative tools`
   });
 
   // Submission Guidelines
@@ -148,13 +137,7 @@ const generateSectionsForCompetition = (competition) => {
     • Technical Quality and Execution (25%)
     • Effective Use of AI Tools (20%)
     • Adherence to Requirements (15%)
-    • Overall Impact and Engagement (10%)
-    
-    **Important Notes:**
-    • Only original submissions accepted
-    • One submission per participant
-    • Late submissions will not be considered
-    • Winners announced within 2 weeks of deadline`
+    • Overall Impact and Engagement (10%)`
   });
 
   return baseSections;

--- a/pages/competitions/[id].js
+++ b/pages/competitions/[id].js
@@ -44,7 +44,7 @@ export default function CompetitionDetailPage({ competition }) {
             Sorry, we couldn&apos;t find the competition youre looking for. It may have been removed or the URL might be incorrect.
           </p>
           <Link 
-            href="/competitions"
+            href="/main"
             className="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
           >
             <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -78,7 +78,7 @@ export default function CompetitionDetailPage({ competition }) {
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-              <Link href="/competitions" className="hover:text-blue-600 transition-colors">
+              <Link href="/main" className="hover:text-blue-600 transition-colors">
                 Competitions
               </Link>
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -90,20 +90,15 @@ export default function CompetitionDetailPage({ competition }) {
         </div>
 
         {/* Main Content */}
-        <main className="max-w-7xl mx-auto px-6 py-8">
+        <main className="px-6 py-8">
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-            {/* Left Panel - Sidebar */}
-            <div className="lg:col-span-3 space-y-6 fixed lg:static w-full lg:w-auto">
-              <SidebarNav sections={competition.sections} />
-            </div>
-
-            {/* Middle Panel - Competition Details */}
-            <div className="lg:col-span-6 space-y-6">
+           {/* Middle Panel - Competition Details */}
+            <div className="lg:col-span-8 space-y-6">
               <CompetitionDetails competition={competition} />
             </div>
 
             {/* Right Panel - Submission Panel */}
-            <div className="lg:col-span-3 space-y-6">
+            <div className="lg:col-span-4 space-y-6">
               <SubmissionPanel competitionId={competition.id} />
             </div>
           </div>


### PR DESCRIPTION
This pull request significantly improves the user experience and code structure for the competition details view, refines navigation, and makes minor adjustments elsewhere in the app. The main focus is a complete redesign of the `CompetitionDetails` component to use a responsive, interactive carousel for competition sections, with keyboard and swipe navigation. Additionally, there are content tweaks and minor UI changes in related files.

**Competition Details Carousel & UI Redesign**

* Refactored `CompetitionDetails.js` to display competition sections as a full-view carousel with smooth transitions, swipe/keyboard navigation, and progress indicators. The layout adapts to viewport size and includes improved header and section styling. [[1]](diffhunk://#diff-55e80f4195ac3d33740f1570ced6a2593c083a788dcc65524dc41f0b214cf374R2-R125) [[2]](diffhunk://#diff-55e80f4195ac3d33740f1570ced6a2593c083a788dcc65524dc41f0b214cf374L103-R149) [[3]](diffhunk://#diff-55e80f4195ac3d33740f1570ced6a2593c083a788dcc65524dc41f0b214cf374L127-R160) [[4]](diffhunk://#diff-55e80f4195ac3d33740f1570ced6a2593c083a788dcc65524dc41f0b214cf374L145-R189) [[5]](diffhunk://#diff-55e80f4195ac3d33740f1570ced6a2593c083a788dcc65524dc41f0b214cf374L168-R255) [[6]](diffhunk://#diff-55e80f4195ac3d33740f1570ced6a2593c083a788dcc65524dc41f0b214cf374L207-R275)
* Added logic for handling touch and pointer events, keyboard navigation, and dynamic slide heights to ensure each section fills the available space below the header.

**Content and Data Updates**

* Trimmed the list of AI tools and removed "Important Notes" from competition section content in `data/competitions.js` for a more concise presentation. [[1]](diffhunk://#diff-2407384ff071f76df8bb842d98e93722d20ea3481559fef5d43db662c01be03aL112-R112) [[2]](diffhunk://#diff-2407384ff071f76df8bb842d98e93722d20ea3481559fef5d43db662c01be03aL151-R140)

**Navigation and Routing**

* Changed fallback and breadcrumb links in `pages/competitions/[id].js` from `/competitions` to `/main` to update navigation paths. ([pages/competitions/[id].jsL47-R47](diffhunk://#diff-21f0f697ed9d37ac1378e9f6765f25e6023da15ce8e967b0a0b8d0ada26da0f4L47-R47), [pages/competitions/[id].jsL81-R81](diffhunk://#diff-21f0f697ed9d37ac1378e9f6765f25e6023da15ce8e967b0a0b8d0ada26da0f4L81-R81))

**Minor UI Adjustments**

* Set text color to black in the submission panel for improved readability and commented out the help section for future use. [[1]](diffhunk://#diff-a7f934aca5eed236d65d2d2a44133b7f4aca96e78ebe38fda1c74da68a620587L131-R131) [[2]](diffhunk://#diff-a7f934aca5eed236d65d2d2a44133b7f4aca96e78ebe38fda1c74da68a620587L320-R320) [[3]](diffhunk://#diff-a7f934aca5eed236d65d2d2a44133b7f4aca96e78ebe38fda1c74da68a620587L336-R336)